### PR TITLE
1 array element missed

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ After the above code executes, `s` is now "bar baz", and `foo` is now "foo".
 ### Splitting a string into an array
     var s = "www.google.com".toSlice();
     var delim = ".".toSlice();
-    var parts = new string[](s.count(delim));
+    var parts = new string[](s.count(delim) + 1);
     for(uint i = 0; i < parts.length; i++) {
         parts[i] = s.split(delim).toString();
     }


### PR DESCRIPTION
In this example
`var s = "www.google.com".toSlice();`
`    var delim = ".".toSlice();`
`    var parts = new string[](s.count(delim) + 1);`

parts should contain three elements `www` / `google` / `com` but there are only two dots in `www.google.com` string.
(count + 1) is required instead of (count) if we want all three parts of the string to be in `parts` array.