### PR TITLE
Correction in comments to compare() function

### DIFF
--- a/strings.sol
+++ b/strings.sol
@@ -185,8 +185,8 @@ library strings {
     }
 
     /*
-     * @dev Returns a positive number if `other` comes lexicographically after
-     *      `self`, a negative number if it comes before, or zero if the
+     * @dev Returns a negative number if `other` comes lexicographically after
+     *      `self`, a positive number if it comes before, or zero if the
      *      contents of the two slices are equal. Comparison is done per-rune,
      *      on unicode codepoints.
      * @param self The first slice to compare.


### PR DESCRIPTION
Reasonably certain that the sign of the return is opposite to that stated in the comment...