### PR TITLE
Add explicit conversions from bytes32 to uint256 to allow binary operations

### DIFF
--- a/src/strings.sol
+++ b/src/strings.sol
@@ -83,23 +83,23 @@ library strings {
         uint ret;
         if (self == 0)
             return 0;
-        if (self & 0xffffffffffffffffffffffffffffffff == 0) {
+        if (uint256(self) & 0xffffffffffffffffffffffffffffffff == 0) {
             ret += 16;
             self = bytes32(uint(self) / 0x100000000000000000000000000000000);
         }
-        if (self & 0xffffffffffffffff == 0) {
+        if (uint256(self) & 0xffffffffffffffff == 0) {
             ret += 8;
             self = bytes32(uint(self) / 0x10000000000000000);
         }
-        if (self & 0xffffffff == 0) {
+        if (uint256(self) & 0xffffffff == 0) {
             ret += 4;
             self = bytes32(uint(self) / 0x100000000);
         }
-        if (self & 0xffff == 0) {
+        if (uint256(self) & 0xffff == 0) {
             ret += 2;
             self = bytes32(uint(self) / 0x10000);
         }
-        if (self & 0xff == 0) {
+        if (uint256(self) & 0xff == 0) {
             ret += 1;
         }
         return 32 - ret;


### PR DESCRIPTION
In solidity 0.5.0 (see https://github.com/ethereum/solidity/pull/4696) we will restrict implicit (and explicit) conversions between number literals and bytesXX types. Among others this will prevent binary operations between bytesXX and hex literals that have a different size (i.e. number of digits) - explicit casts become necessary. This PR adds the necessary explicit conversions to ``strings.sol``.
