### PR TITLE
Fix for crash bug in memcpy

### DIFF
--- a/src/strings.sol
+++ b/src/strings.sol
@@ -44,7 +44,7 @@ library strings {
 
     function memcpy(uint dest, uint src, uint len) private pure {
         // Copy word-length chunks while possible
-        for(; len >= 32; len -= 32) {
+        for(; len > 32; len -= 32) {
             assembly {
                 mstore(dest, mload(src))
             }


### PR DESCRIPTION
If toString is run on an exactly 32 character slice, memcpy will crash. It took me more hours than I care to admit to find and fix this. Hope this can be merged or at least that this PR will serve as a warning to anyone else who may run into this. :)