### PR TITLE
Fix shadowing warning

### DIFF
--- a/src/strings.sol
+++ b/src/strings.sol
@@ -42,9 +42,9 @@ library strings {
         uint _ptr;
     }
 
-    function memcpy(uint dest, uint src, uint len) private pure {
+    function memcpy(uint dest, uint src, uint length) private pure {
         // Copy word-length chunks while possible
-        for(; len >= 32; len -= 32) {
+        for(; length >= 32; length -= 32) {
             assembly {
                 mstore(dest, mload(src))
             }
@@ -54,8 +54,8 @@ library strings {
 
         // Copy remaining bytes
         uint mask = type(uint).max;
-        if (len > 0) {
-            mask = 256 ** (32 - len) - 1;
+        if (length > 0) {
+            mask = 256 ** (32 - length) - 1;
         }
         assembly {
             let srcpart := and(mload(src), not(mask))


### PR DESCRIPTION
The following warning is displayed when compiling.
This PR will modify so that the warning is not displayed.
See also https://github.com/ethereum/solidity/pull/12680 for more information on this style.

```
Warning: This declaration shadows an existing declaration.
  --> src/strings.sol:45:42:
   |
45 |     function memcpy(uint dest, uint src, uint len) private pure {
   |                                          ^^^^^^^^
Note: The shadowed declaration is here:
  --> src/strings.sol:85:5:
   |
85 |     function len(bytes32 self) internal pure returns (uint) {
   |     ^ (Relevant source part starts here and spans across multiple lines).
Note: The shadowed declaration is here:
   --> src/strings.sol:160:5:
    |
160 |     function len(slice memory self) internal pure returns (uint l) {
    |     ^ (Relevant source part starts here and spans across multiple lines).
```